### PR TITLE
Capture duration and query for queries logged with log_min_duration_statement

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,9 @@ const toArray = require('stream-to-array');
 
 const postgresCSVLog = require('../index');
 
+// Note that each test case processes the entire file despite only checking parts of the output. It's potentially worth refactoring this to
+// remove the repeated processing.
+
 it('should correctly parse error log lines', (done) => {
   stream = fs.createReadStream('test/test_log.csv').pipe(postgresCSVLog());
   toArray(stream, (err, arr) => {

--- a/test/test_log.csv
+++ b/test/test_log.csv
@@ -10,3 +10,4 @@ Merge Join  (cost=119.66..199.66 rows=5000 width=4)
         Sort Key: f.i
         ->  Function Scan on generate_series f  (cost=0.00..10.00 rows=1000 width=4)",,,,,,,,,"psql"
 2016-03-12 15:59:52.853 PST,"primaryuser","maindb",689,"127.0.0.1:60135",56e4aaeb.2b1,4,"SELECT",2016-03-12 15:48:59 PST,2/0,0,LOG,00000,"duration: 2.277 ms  plan: not a valid entry.",,,,,,,,,"psql"
+2016-03-12 15:59:55.753 PST,"primaryuser","maindb",42,"127.0.0.1:60135",5ad52121.2a,5,"SELECT",2016-03-12 15:49:59 PST,2/0,0,LOG,00000,"duration: 3199.456 ms  statement: select * from generate_series(1,2000000) g(i) natural join generate_series(1,2000000) f(i);",,,,,,,,,"psql"


### PR DESCRIPTION
The CSV parsing currently only supports logging the plan, duration, and query for queries logged using `auto_explain`. We still want the duration of queries run with auto_explain disabled (using the `log_min_duration_statement` mechanism). This adds support for parsing log lines generated by both `auto_explain` and `log_min_duration_statement`.

This PR also does a few refactors to make the code more readable.